### PR TITLE
XD-1454 User does not have to specify a control transport

### DIFF
--- a/src/main/java/org/springframework/xd/ec2/cloud/AWSDeployer.java
+++ b/src/main/java/org/springframework/xd/ec2/cloud/AWSDeployer.java
@@ -101,9 +101,7 @@ public class AWSDeployer implements Deployer {
 
 	private transient String numberOfInstances;
 
-	private transient String controlTransport;
-
-	private transient String dataTransport;
+	private transient String transport;
 	
 	private transient int managementPort;
 
@@ -132,8 +130,7 @@ public class AWSDeployer implements Deployer {
 		userName = properties.getProperty("user-name");
 		region = properties.getProperty("region");
 		numberOfInstances = properties.getProperty("number-nodes");
-		controlTransport = properties.getProperty("xd-control-transport");
-		dataTransport = properties.getProperty("xd-data-transport");
+		transport = properties.getProperty("xd-transport");
 		managementPort = Integer.parseInt(properties.getProperty("management.port"));
 
 		ComputeServiceContext context = ContextBuilder.newBuilder("aws-ec2")
@@ -204,7 +201,7 @@ public class AWSDeployer implements Deployer {
 		instance = AWSInstanceProvisioner.findInstanceById(client,
 				instance.getId());
 		return deploySingleServer(configurer.createAdminNodeScript(
-				instance.getDnsName(), controlTransport), instance,
+				instance.getDnsName()), instance,
 				InstanceType.ADMIN);
 	}
 
@@ -340,7 +337,7 @@ public class AWSDeployer implements Deployer {
 					inner.start("installContainerServer");
 					Deployment deployment = installContainerServer(
 							configurer.createContainerNodeScript(hostName,
-									controlTransport, dataTransport),
+									transport),
 							refreshed, InstanceType.NODE);
 					inner.stop();
 					LOGGER.debug(inner.prettyPrint());

--- a/src/main/java/org/springframework/xd/ec2/cloud/AWSInstanceConfigurer.java
+++ b/src/main/java/org/springframework/xd/ec2/cloud/AWSInstanceConfigurer.java
@@ -103,8 +103,8 @@ public class AWSInstanceConfigurer implements InstanceConfigurer {
 	 * @param hostName
 	 * @return
 	 */
-	public String createAdminNodeScript(String hostName, String transport) {
-		return renderStatement(deployAdminNodeXDStatement(hostName, transport));
+	public String createAdminNodeScript(String hostName) {
+		return renderStatement(deployAdminNodeXDStatement(hostName));
 	}
 
 	/**
@@ -114,9 +114,9 @@ public class AWSInstanceConfigurer implements InstanceConfigurer {
 	 * @return
 	 */
 	public String createContainerNodeScript(String hostName,
-			String controlTransport, String dataTransport) {
+			String transport) {
 		return renderStatement(deployContainerNodeXDStatement(hostName,
-				controlTransport, dataTransport));
+				transport));
 	}
 
 	/**
@@ -194,8 +194,7 @@ public class AWSInstanceConfigurer implements InstanceConfigurer {
 	 * @param hostName
 	 * @return the script that will used to initialize the application.
 	 */
-	private List<Statement> deployAdminNodeXDStatement(String hostName,
-			String transport) {
+	private List<Statement> deployAdminNodeXDStatement(String hostName) {
 		List<Statement> result = initializeEnvironmentStatements(hostName,
 				false);
 		LOGGER.info("Using the following host to obtain XD Distribution: "
@@ -204,8 +203,7 @@ public class AWSInstanceConfigurer implements InstanceConfigurer {
 		result.add(exec("unzip " + UBUNTU_HOME + getFileName() + " -d "
 				+ UBUNTU_HOME));
 		result.add(exec(constructConfigurationCommand(hostName)));
-		result.add(exec(getBinDirectory() + "xd-admin "
-				+ getControlTransportString(transport) + " &"));
+		result.add(exec(getBinDirectory() + "xd-admin &"));
 		return result;
 	}
 
@@ -221,7 +219,7 @@ public class AWSInstanceConfigurer implements InstanceConfigurer {
 	 * @return the script that will used to initialize the application.
 	 */
 	private List<Statement> deployContainerNodeXDStatement(String hostName,
-			String controlTransport, String transport) {
+			 String transport) {
 		List<Statement> result = initializeEnvironmentStatements(hostName,
 				false);
 		result.add(exec("export XD_HOME=" + getInstalledDirectory() + "/xd"));
@@ -232,23 +230,11 @@ public class AWSInstanceConfigurer implements InstanceConfigurer {
 				+ UBUNTU_HOME));
 		result.add(exec(constructConfigurationCommand(hostName)));
 		result.add(exec(getBinDirectory() + "xd-container "
-				+ getControlTransportString(controlTransport) + " "
-				+ getDataTransportString(transport) + " &"));
+				+ getTransportString(transport) + " &"));
 		return result;
 	}
 
-
-	private String getControlTransportString(String transport) {
-		final String BASE_TRANSPORT_PREFIX = "--controlTransport ";
-		String result = "";
-		if (transport != null && transport.length() > 0) {
-			result = BASE_TRANSPORT_PREFIX + transport;
-		}
-		return result;
-	}
-
-
-	private String getDataTransportString(String transport) {
+	private String getTransportString(String transport) {
 		final String BASE_TRANSPORT_PREFIX = "--transport ";
 		String result = "";
 		if (transport != null && transport.length() != 0) {

--- a/src/main/resources/xd-ec2.properties
+++ b/src/main/resources/xd-ec2.properties
@@ -15,8 +15,7 @@ xd-zip-cache-url=https://s3.amazonaws.com/XDZipImages
 ami=ami-a94349c0
 description=XD-Instance
 xd-release=spring-xd-1.0.0.BUILD-SNAPSHOT
-xd-control-transport=rabbit
-xd-data-transport=rabbit
+xd-transport=rabbit
 
 
 #XD Properties

--- a/src/test/java/org/springframework/xd/ec2/cloud/TestAWSInstanceConfigurer.java
+++ b/src/test/java/org/springframework/xd/ec2/cloud/TestAWSInstanceConfigurer.java
@@ -94,7 +94,7 @@ public class TestAWSInstanceConfigurer {
 	 */
 	@Test
 	public void testDeployContainerApplication() {
-		String result = configurer.createContainerNodeScript("MYHOST","redis","redis");
+		String result = configurer.createContainerNodeScript("MYHOST","redis");
 		assertTrue("Was not able to find the rabbit port configuration.",result.indexOf(RABBIT_CONFIG)>-1);
 		assertTrue("Was not able to find the redis port configuration.",result.indexOf(REDIS_CONFIG)>-1);
 


### PR DESCRIPTION
Removed control and data transport checks.

This allows the user to set either redis, rabbit or nothing for data and control transport.
This config maybe removed in the future.
