### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@
 	
 	buildscript {
 		repositories {
-			maven { url 'http://repo.spring.io/plugins-snapshot' }
-			maven { url 'http://repo.spring.io/plugins-release' }
+			maven { url 'https://repo.spring.io/plugins-snapshot' }
+			maven { url 'https://repo.spring.io/plugins-release' }
 		}
 		dependencies {
 			classpath("org.springframework.build.gradle:propdeps-plugin:0.0.3")
@@ -23,7 +23,7 @@
 	
 	repositories {
 	    mavenCentral()
-	    maven { url "http://repo.springsource.org/plugins-snapshot" }
+	    maven { url "https://repo.springsource.org/plugins-snapshot" }
 	}
 	
 	task setupProject {
@@ -62,7 +62,7 @@
 	    linkScmConnection    = 'https://github.com/spring-projects/spring-xd-ec2.git'
 	    linkScmDevConnection = 'git@github.com:spring-projects/spring-xd-ec2.git'
 		javadocLinks = [
-			"http://static.springsource.org/spring-shell/docs/current/api/"
+			"https://docs.spring.io/spring-shell/docs/current/api/"
 		] as String[]
 	
 		}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://static.springsource.org/spring-shell/docs/current/api/ (301) migrated to:  
  https://docs.spring.io/spring-shell/docs/current/api/ ([https](https://static.springsource.org/spring-shell/docs/current/api/) result 200).
* http://repo.springsource.org/plugins-snapshot migrated to:  
  https://repo.springsource.org/plugins-snapshot ([https](https://repo.springsource.org/plugins-snapshot) result 301).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).
* http://repo.spring.io/plugins-snapshot migrated to:  
  https://repo.spring.io/plugins-snapshot ([https](https://repo.spring.io/plugins-snapshot) result 302).